### PR TITLE
Updated README.md to fix typo in token creation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Get read only member token:
 
 Get read / write member token:
 
-    https://trello.com/1/authorize?key=YOUR_API_KEY&name=trello-cli=1day&response_type=token&scope=read,write
+    https://trello.com/1/authorize?key=YOUR_API_KEY&name=trello-cli&expires=1day&response_type=token&scope=read,write
 
 Set the environment variables:
 


### PR DESCRIPTION
I believe you're missing "expires=1day" in this line of the README.md
