### PR TITLE
remove .rvmrc in favor of newer .ruby-{gemset,version} files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
 *.rbc
+.ruby-*
+.rvmrc
 .bundle
 .config
 .yardoc

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use ruby-1.9.3-p385@trello_cli --create


### PR DESCRIPTION
going forward, rvm (and other ruby version managers) are going to be using .ruby-version, as well as .ruby-gemset

This change deprecates the older .rvmrc file.
