### PR TITLE
gemspec to ignore dev files

### DIFF
--- a/trello_cli.gemspec
+++ b/trello_cli.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/brettweavnet/trello_cli"
 
   gem.files         = `git ls-files`.split($/)
+  gem.files         -= gem.files.grep(%r{^\.})
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
This is just a little OCD, but you don't have to distribute the hidden files when you package your gem.
