### PR TITLE
Set expiration of read/write token to never

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Get read only member token:
 
 Get read / write member token:
 
-    https://trello.com/1/authorize?key=YOUR_API_KEY&name=trello-cli&expires=1day&response_type=token&scope=read,write
+    https://trello.com/1/authorize?key=YOUR_API_KEY&name=trello-cli&expiration=never&response_type=token&scope=read,write
 
 Set the environment variables:
 


### PR DESCRIPTION
Why 1 day expiration? Is it better to setup it to never? It's more useful in daily usage and save potential users a time to find how to change it.
